### PR TITLE
KeyRange::prefix: handle empty values gracefully

### DIFF
--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -172,6 +172,12 @@ impl KeyRange {
         K: Into<Vec<u8>>,
     {
         let key = prefix.into();
+        if key.is_empty() {
+            // An empty Vec<u8> results in an invalid KeyRange.
+            // Assume that an empty value passed to this method implies no prefix (i.e., all keys).
+            return KeyRange::all();
+        }
+
         let range_end = {
             let mut end = key.clone();
 


### PR DESCRIPTION
To request all keys from Etcd a special KeyRange value containing null bytes is prepared by `KeyRange::all`. When `KeyRange::prefix` is called with an empty string, the expected behaviour is for it to behave as `KeyRange::all` does. This commit makes `KeyRange::prefix` return the special 'no-prefix' `KeyRange` when the input is empty.

# Usage

`namespace` is a `&str` provided by the user, which may be an empty string.

## Before

```rust
let req = match namespace {
    "" => RangeRequest::new(KeyRange::all()),
    namespace => RangeRequest::new(KeyRange::prefix(namespace))
};
```

## After

```rust
let req = RangeRequest::new(KeyRange::prefix(namespace));
```