### PR TITLE
Allow configure max request/response message size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etcd-rs"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["lodrem <jialun.cai@pm.me>"]
 edition = "2021"
 keywords = ["etcd", "future", "async"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -250,6 +250,7 @@ impl Client {
         }
     }
 
+    // Set gRPC maximum size of a decoded message
     pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
         self.auth_client = self.auth_client.max_decoding_message_size(limit);
         self.kv_client = self.kv_client.max_decoding_message_size(limit);
@@ -259,6 +260,8 @@ impl Client {
 
         self
     }
+
+    // Set gRPC maximum size of an encoded message
     pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
         self.auth_client = self.auth_client.max_encoding_message_size(limit);
         self.kv_client = self.kv_client.max_encoding_message_size(limit);

--- a/src/client.rs
+++ b/src/client.rs
@@ -249,6 +249,25 @@ impl Client {
             None => Ok(cli),
         }
     }
+
+    pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+        self.auth_client = self.auth_client.max_decoding_message_size(limit);
+        self.kv_client = self.kv_client.max_decoding_message_size(limit);
+        self.watch_client = self.watch_client.max_decoding_message_size(limit);
+        self.cluster_client = self.cluster_client.max_decoding_message_size(limit);
+        self.lease_client = self.lease_client.max_decoding_message_size(limit);
+
+        self
+    }
+    pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+        self.auth_client = self.auth_client.max_encoding_message_size(limit);
+        self.kv_client = self.kv_client.max_encoding_message_size(limit);
+        self.watch_client = self.watch_client.max_encoding_message_size(limit);
+        self.cluster_client = self.cluster_client.max_encoding_message_size(limit);
+        self.lease_client = self.lease_client.max_encoding_message_size(limit);
+
+        self
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
In tonic 0.9 [#1274](https://github.com/hyperium/tonic/pull/1274), limits the response body size to 4MiB.

For some large etcd values it's unacceptable, so give user the option to change it.